### PR TITLE
Set MIT copyright holder to Faletto & Bien (fix placeholder)

### DIFF
--- a/cssr/DESCRIPTION
+++ b/cssr/DESCRIPTION
@@ -2,8 +2,8 @@ Package: cssr
 Title: Cluster Stability Selection
 Version: 0.1.9
 Authors@R: c(
-    person("Gregory", "Faletto", , "gregory.faletto@marshall.usc.edu", role = c("aut", "cre")),
-    person("Jacob", "Bien", , "jbien@usc.edu", role = "aut")
+    person("Gregory", "Faletto", , "gregory.faletto@marshall.usc.edu", role = c("aut", "cre", "cph")),
+    person("Jacob", "Bien", , "jbien@usc.edu", role = c("aut", "cph"))
   )
 Description: Implementation of Cluster Stability Selection (Faletto and
     Bien 2022).
@@ -18,4 +18,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 LitrVersionUsed: 0.9.3
-LitrId: 9771bb9f19b06385e74684370d8e4976
+LitrId: f5156080c2289c063d78784a7c8e48c8

--- a/cssr/LICENSE
+++ b/cssr/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2026
-COPYRIGHT HOLDER: F. Last
+COPYRIGHT HOLDER: Gregory Faletto and Jacob Bien

--- a/cssr/LICENSE.md
+++ b/cssr/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2026 F. Last
+Copyright (c) 2026 Gregory Faletto and Jacob Bien
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cssr/man/cssr-package.Rd
+++ b/cssr/man/cssr-package.Rd
@@ -16,12 +16,12 @@ more about this package, please visit its website
 \code{\link{css}} \code{\link{cssSelect}}
 }
 \author{
-\strong{Maintainer}: Gregory Faletto \email{gregory.faletto@marshall.usc.edu}
+\strong{Maintainer}: Gregory Faletto \email{gregory.faletto@marshall.usc.edu} [copyright holder]
 
 Authors:
 \itemize{
-  \item Gregory Faletto \email{gregory.faletto@marshall.usc.edu}
-  \item Jacob Bien \email{jbien@usc.edu}
+  \item Gregory Faletto \email{gregory.faletto@marshall.usc.edu} [copyright holder]
+  \item Jacob Bien \email{jbien@usc.edu} [copyright holder]
 }
 
 }

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -30,7 +30,7 @@
     </div>
 
 <pre>YEAR: 2026
-COPYRIGHT HOLDER: F. Last
+COPYRIGHT HOLDER: Gregory Faletto and Jacob Bien
 </pre>
 
   </main></div>

--- a/docs/LICENSE-text.md
+++ b/docs/LICENSE-text.md
@@ -1,4 +1,4 @@
 # License
 
     YEAR: 2026
-    COPYRIGHT HOLDER: F. Last
+    COPYRIGHT HOLDER: Gregory Faletto and Jacob Bien

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -31,7 +31,7 @@
 
 <div id="mit-license" class="section level1">
 
-<p>Copyright (c) 2026 F. Last</p>
+<p>Copyright (c) 2026 Gregory Faletto and Jacob Bien</p>
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
 <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
 <p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2026 F. Last
+Copyright (c) 2026 Gregory Faletto and Jacob Bien
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -32,11 +32,11 @@
       <h2>Authors</h2>
 
       <ul class="list-unstyled"><li>
-          <p><strong><a href="https://gregoryfaletto.com/" class="external-link">Gregory Faletto</a></strong>. Author, maintainer.
+          <p><strong><a href="https://gregoryfaletto.com/" class="external-link">Gregory Faletto</a></strong>. Author, maintainer, copyright holder.
           </p>
         </li>
         <li>
-          <p><strong><a href="http://faculty.marshall.usc.edu/jacob-bien/" class="external-link">Jacob Bien</a></strong>. Author.
+          <p><strong><a href="http://faculty.marshall.usc.edu/jacob-bien/" class="external-link">Jacob Bien</a></strong>. Author, copyright holder.
           </p>
         </li>
       </ul></div>

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -3,9 +3,10 @@
 ## Authors
 
 - **[Gregory Faletto](https://gregoryfaletto.com/)**. Author,
-  maintainer.
+  maintainer, copyright holder.
 
-- **[Jacob Bien](http://faculty.marshall.usc.edu/jacob-bien/)**. Author.
+- **[Jacob Bien](http://faculty.marshall.usc.edu/jacob-bien/)**. Author,
+  copyright holder.
 
 ## Citation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,9 +296,9 @@ Selection Proportions
 <h2 data-toc-skip>Developers</h2>
 <ul class="list-unstyled">
 <li>
-<a href="https://gregoryfaletto.com/" class="external-link">Gregory Faletto</a> <br><small class="roles"> Author, maintainer </small>   </li>
+<a href="https://gregoryfaletto.com/" class="external-link">Gregory Faletto</a> <br><small class="roles"> Author, maintainer, copyright holder </small>   </li>
 <li>
-<a href="http://faculty.marshall.usc.edu/jacob-bien/" class="external-link">Jacob Bien</a> <br><small class="roles"> Author </small>   </li>
+<a href="http://faculty.marshall.usc.edu/jacob-bien/" class="external-link">Jacob Bien</a> <br><small class="roles"> Author, copyright holder </small>   </li>
 </ul>
 </div>
 

--- a/docs/reference/cssr-package.html
+++ b/docs/reference/cssr-package.html
@@ -53,9 +53,9 @@ more about this package, please visit its website
     </div>
     <div class="section level2">
     <h2 id="author">Author<a class="anchor" aria-label="anchor" href="#author"></a></h2>
-    <p><strong>Maintainer</strong>: Gregory Faletto <a href="mailto:gregory.faletto@marshall.usc.edu">gregory.faletto@marshall.usc.edu</a></p>
-<p>Authors:</p><ul><li><p>Gregory Faletto <a href="mailto:gregory.faletto@marshall.usc.edu">gregory.faletto@marshall.usc.edu</a></p></li>
-<li><p>Jacob Bien <a href="mailto:jbien@usc.edu">jbien@usc.edu</a></p></li>
+    <p><strong>Maintainer</strong>: Gregory Faletto <a href="mailto:gregory.faletto@marshall.usc.edu">gregory.faletto@marshall.usc.edu</a> [copyright holder]</p>
+<p>Authors:</p><ul><li><p>Gregory Faletto <a href="mailto:gregory.faletto@marshall.usc.edu">gregory.faletto@marshall.usc.edu</a> [copyright holder]</p></li>
+<li><p>Jacob Bien <a href="mailto:jbien@usc.edu">jbien@usc.edu</a> [copyright holder]</p></li>
 </ul></div>
 
   </main><aside class="col-md-3"><nav id="toc" aria-label="Table of contents"><h2>On this page</h2>

--- a/docs/reference/cssr-package.md
+++ b/docs/reference/cssr-package.md
@@ -13,9 +13,11 @@ please visit its website <https://gregfaletto.github.io/cssr-project/>.
 ## Author
 
 **Maintainer**: Gregory Faletto <gregory.faletto@marshall.usc.edu>
+\[copyright holder\]
 
 Authors:
 
-- Gregory Faletto <gregory.faletto@marshall.usc.edu>
+- Gregory Faletto <gregory.faletto@marshall.usc.edu> \[copyright
+  holder\]
 
-- Jacob Bien <jbien@usc.edu>
+- Jacob Bien <jbien@usc.edu> \[copyright holder\]

--- a/index.Rmd
+++ b/index.Rmd
@@ -114,16 +114,16 @@ usethis::create_package(
       given = "Gregory",
       family = "Faletto",
       email = "gregory.faletto@marshall.usc.edu",
-      role = c("aut", "cre")
+      role = c("aut", "cre", "cph")
       ), person(
       given = "Jacob",
       family = "Bien",
       email = "jbien@usc.edu",
-      role = c("aut")
+      role = c("aut", "cph")
       ))
   )
 )
-usethis::use_mit_license(copyright_holder = "F. Last")
+usethis::use_mit_license(copyright_holder = "Gregory Faletto and Jacob Bien")
 ```
 
 We also define the package-level documentation that shows up when someone types `package?cssr` in the console:


### PR DESCRIPTION
Fixes the MIT license's placeholder copyright holder. The package shipped with `Copyright (c) 2026 F. Last`; this sets it to **Gregory Faletto and Jacob Bien** via `use_mit_license()` in `index.Rmd` and adds the `cph` role to both authors in `Authors@R`. **License type is unchanged — still MIT.** `devtools::check(args = "--as-cran")` is 0/0/0.

Regenerated and committed (14 files): `LICENSE`, `LICENSE.md`, `DESCRIPTION`, `man/cssr-package.Rd`, and the pkgdown `LICENSE` / `authors` / `index` / `reference` pages. I ran `devtools::document` after the litr build so the man-page comment style matches `main` — otherwise the 61 unrelated man pages flip comment style and show up as spurious diffs (see #22).

## Out of scope (deferred follow-ups)

- **`docs/create/*` (litr "create" book) and `docs/search.json` still show "F. Last"** — left at `main` on purpose: they churn non-deterministically every build (random testthat celebration emojis in rendered chunk output; full search reindex), so committing them would bury this change under noise. The authoritative `LICENSE`/`LICENSE.md`/`DESCRIPTION` and the user-facing pkgdown license/authors pages are all correct; these two will refresh on the next deterministic rebuild. Tracked by #22. (Say the word if you'd rather I scrub them now.)
