### PR TITLE
Add docs/.nojekyll: fix GitHub Pages deploy (Jekyll build failure)

### DIFF
--- a/build.R
+++ b/build.R
@@ -44,3 +44,12 @@ stopifnot("litr::render did not produce _book/" = fs::dir_exists("_book"))
 if (fs::dir_exists("docs/create")) fs::dir_delete("docs/create")
 fs::dir_copy("_book", "docs/create")
 fs::dir_delete("_book")
+
+# Disable Jekyll on the published site. GitHub Pages for this repo is the legacy
+# branch build (main /docs), which runs Jekyll over docs/ by default. cssr's site
+# is static (the pkgdown site + the litr "create" book), and Jekyll's Liquid
+# parser can choke on generated content, failing the Pages build ("Page build
+# failed", as it did on the #117 merge). An empty .nojekyll at the site root
+# tells GitHub Pages to serve docs/ as-is and skip Jekyll entirely. litr's
+# add_pkgdown() does not emit one at the published root, so create it here.
+if (!fs::file_exists("docs/.nojekyll")) fs::file_create("docs/.nojekyll")


### PR DESCRIPTION
Fixes the failing GitHub Pages deployment (run 28608072735 — failed twice on the #117 merge commit).

### Root cause
The repo's Pages is the **legacy branch build** (`build_type: legacy`, source `main /docs`), which runs **Jekyll** over `docs/` by default. cssr's site is static (pkgdown + the litr "create" book) and has **no `.nojekyll`**, so Jekyll has always processed it. It succeeded until the #117 merge regenerated `docs/` (~10.5k lines changed) with content Jekyll's Liquid parser couldn't handle → the GitHub-side Pages build errored (`status: errored`, `"Page build failed"`), which left `actions/deploy-pages` stuck in `deployment_queued` until it timed out (`Deployment failed, try again later`). **Not a GitHub outage** — status showed Pages operational throughout; the failure is the Jekyll build.

### Fix
- Add an empty **`docs/.nojekyll`** at the site root → GitHub Pages skips Jekyll and serves `docs/` as-is.
- Add a `build.R` step (`fs::file_create("docs/.nojekyll")`) so every `Rscript build.R` keeps it (litr's `add_pkgdown()` doesn't emit one at the published root).

### Notes
- **Docs/CI-only — no package change, no version bump** (`.nojekyll` lives in `docs/`, not `cssr/`).
- Confirmed `.nojekyll` isn't gitignored and was never previously tracked.
- The real test is the deploy itself: once merged, the next Pages build should skip Jekyll and publish 0.2.1 (and 0.3.0 when #121 lands). I'll watch the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4B1w4pb2eVYVjWqT51jDS
