### PR TITLE
Switch GitHub Pages to Actions deploy (fix recurring legacy-build failures)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+# Deploy the litr-generated docs/ site to GitHub Pages via GitHub Actions.
+#
+# This replaces the deprecated legacy "deploy from a branch" (main /docs) build,
+# which was intermittently dropping builds on GitHub's backend (deploys stuck in
+# "building" -> "Deployment failed, try again later"). The site is pre-built into
+# docs/ by `Rscript build.R` (litr); this workflow just uploads docs/ and deploys
+# it -- no Jekyll, no server-side build step.
+#
+# One-time setup outside this file: set the repo's Pages source to "GitHub
+# Actions" (Settings -> Pages, or `gh api -X PUT repos/OWNER/REPO/pages -f
+# build_type=workflow`).
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least-privilege permissions the deploy-pages action needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one Pages deployment at a time; let an in-progress one finish rather than
+# cancelling it (avoids half-published states).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload docs/ as the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes the **recurring GitHub Pages deploy failures** (2nd in ~12h — runs on `3a3e74d8` and `2093dfc5`), each a GitHub-side stuck *legacy* build that only cleared on a manual re-run.

### Root cause
Pages is on the **legacy branch-build** (`build_type: legacy`, deploy from `main /docs`) — deprecated, and its backend has been intermittently getting stuck (`"building"` → `Deployment failed, try again later`). The `.nojekyll` fix (#122) resolved the Jekyll *build* failure but not the legacy backend's stuck-build flakiness.

### Fix
Adds `.github/workflows/pages.yml` — the modern **GitHub Actions Pages** deploy: on push to `main` (and manual dispatch), it uploads the pre-built `docs/` as a Pages artifact and deploys via `actions/deploy-pages`. No server-side Jekyll/build step; far more reliable than the legacy branch-build.

### One-time setup after merge
Flip the repo's Pages source to **GitHub Actions**:
```
gh api -X PUT repos/gregfaletto/cssr-project/pages -f build_type=workflow
```
(or Settings → Pages → Source → "GitHub Actions"). I'll do this right after you merge, then trigger + verify the first Actions deploy publishes 0.3.4. The currently-published site stays live until then.

### Notes
- **CI-only — no package change, no version bump.** `.github/` isn't touched by `Rscript build.R`.
- `.nojekyll` is kept (harmless; the Actions flow serves the artifact statically anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4B1w4pb2eVYVjWqT51jDS
